### PR TITLE
Abstract the store definition generation to the store container

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _Simple, atomic state management._
 
-[![npm version](https://badge.fury.io/js/apps-digest.svg)](https://badge.fury.io/js/apps-digest) [![Featured on Openbase](https://badges.openbase.com/js/featured/apps-digest.svg?style=openbase&token=LuCH/H1y5l8aDjsBIRWlzGDU0e1s+qmuz7E4bsIfFoQ=)](https://openbase.com/js/apps-digest?utm_source=embedded&amp;utm_medium=badge&amp;utm_campaign=rate-badge)
+[![npm version](https://badge.fury.io/js/apps-digest.svg)](https://badge.fury.io/js/apps-digest) [![Featured on Openbase](https://badges.openbase.com/js/featured/apps-digest.svg?style=openbase&token=LuCH/H1y5l8aDjsBIRWlzGDU0e1s+qmuz7E4bsIfFoQ=)](https://openbase.com/js/apps-digest?utm_source=embedded&utm_medium=badge&utm_campaign=rate-badge)
 
 ---
 
@@ -38,7 +38,7 @@ With App's Digest you can manage your application state outside of any UI framew
 
 ## Prerequisites
 
-- Node >= 12
+- Node >= 14
 - React >= 16.9.0 (Optional)
 
 ## Installation
@@ -50,8 +50,13 @@ npm install apps-digest
 ## A quick example
 
 ```javascript
-// Counter Store
-import { AppsDigestValue, generateStoreDefinition } from 'apps-digest';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {
+  AppsDigestValue,
+  useAppsDigestStore,
+  useAppsDigestValue,
+} from 'apps-digest';
 
 class CounterStore {
   count = new AppsDigestValue(0);
@@ -61,14 +66,6 @@ class CounterStore {
     this.count.publish(currentCount + 1);
   }
 }
-
-export default generateStoreDefinition(CounterStore);
-
-// Counter View
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { useAppsDigestStore, useAppsDigestValue } from 'apps-digest';
-import CounterStore from './CounterStore';
 
 const CounterView = () => {
   const counterStore = useAppsDigestStore(CounterStore);
@@ -91,7 +88,7 @@ App's Digest leverages on two software architecture patterns:
 - IoC Container pattern (a.k.a. DI Container) to manage store instantiation, dependency injection and lifecycle.
 - The publisher-subscriber pattern to implement values within the stores that any JavaScript context (including React components) can subscribe and publish to.
 
-![App's Digest Flow](https://raw.githubusercontent.com/martyroque/emrock-blog/22a90734b18b9642bd4012c11ced3dbf7ea6db98/public/images/apps_digest_flow.jpeg)
+![App's Digest Flow](https://emrock-app.s3.us-east-2.amazonaws.com/uploads/apps-digest-flow.png)
 
 ### What's a Store?
 
@@ -104,13 +101,14 @@ Let's take a closer look on how to use the library.
 ### Create a store
 
 First, let's create our store. A store is a class that implements the following:
+
 - Store value(s) by instantiating `AppsDigestValue` with an initial value (required).
 - Value setters that publish (updates) the store values (optional).
 
-Once the store has been created, we need to generate the store definition, which will be used by the container to identify our store in memory.
+Note: It is a good pattern to keep your stores separate from your UI.
 
 ```javascript
-import { AppsDigestValue, generateStoreDefinition } from 'apps-digest';
+import { AppsDigestValue } from 'apps-digest';
 
 class CounterStore {
   count = new AppsDigestValue(0);
@@ -121,7 +119,7 @@ class CounterStore {
   }
 }
 
-export default generateStoreDefinition(CounterStore);
+export default CounterStore;
 ```
 
 ### Use the store anywhere
@@ -194,11 +192,7 @@ With App's Digest, we can have segregated stores that contain a small meaningful
 Let's say we have a store that needs to read the count value from our `CounterStore`. We can easily inject the store like this:
 
 ```javascript
-import {
-  AppsDigestValue,
-  AppsDigestStore,
-  generateStoreDefinition,
-} from 'apps-digest';
+import { AppsDigestValue, AppsDigestStore } from 'apps-digest';
 import CounterStore from './CounterStore';
 
 class ApplicationStore extends AppsDigestStore {
@@ -216,7 +210,7 @@ class ApplicationStore extends AppsDigestStore {
   }
 }
 
-export default generateStoreDefinition(ApplicationStore);
+export default ApplicationStore;
 ```
 
 By extending from `AppsDigestStore`, we get the automatic un-subscription for free when the store is disposed.
@@ -228,11 +222,11 @@ In order to persist a store value, we need to specify the persist key we would l
 Every time the value is published, the value will be persisted. And, the next time the store is instantiated, the value will be rehydrated.
 
 ```javascript
-  // assuming CountValue was persisted as 2, count will be hydrated with 2 instead of 0
-  count = new AppsDigestValue(0, 'CountValue');
+// assuming CountValue was persisted as 2, count will be hydrated with 2 instead of 0
+count = new AppsDigestValue(0, 'CountValue');
 
-  // this will persist the new value
-  this.count.publish(currentCount + 1);
+// this will persist the new value
+this.count.publish(currentCount + 1);
 ```
 
 ## Computed Values
@@ -244,23 +238,19 @@ Let's say we have a store that manages the user session, and we have a `isAuth` 
 ### ApiStore
 
 ```javascript
-import { AppsDigestValue, generateStoreDefinition } from 'apps-digest';
+import { AppsDigestValue } from 'apps-digest';
 
 class ApiStore {
   isConnected = new AppsDigestValue(false);
 }
 
-export default generateStoreDefinition(ApiStore);
+export default ApiStore;
 ```
 
 ### UserStore
 
 ```javascript
-import {
-  AppsDigestValue,
-  AppsDigestStore,
-  generateStoreDefinition,
-} from 'apps-digest';
+import { AppsDigestValue, AppsDigestStore } from 'apps-digest';
 import ApiStore from './ApiStore';
 
 class UserStore extends AppsDigestStore {
@@ -274,13 +264,13 @@ class UserStore extends AppsDigestStore {
   );
 }
 
-export default generateStoreDefinition(UserStore);
+export default UserStore;
 ```
 
 With this, `shouldMakeRequest` will track both `isAuth` and `isConnected` values and produce a single `boolean` value as a result. This computed value can be used as a regular store value anywhere in our app.
 
 ```javascript
-import React, {useEffect} from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { useAppsDigestStore, useAppsDigestValue } from 'apps-digest';
 import UserStore from './UserStore';
@@ -311,4 +301,4 @@ ReactDOM.render(<App />, document.body);
 
 [ISC License](LICENSE)
 
-Copyright © 2022 [Marty Roque](https://github.com/martyroque).
+Copyright © 2023 [Marty Roque](https://github.com/martyroque).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apps-digest",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apps-digest",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Simple, atomic state management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -9,7 +9,7 @@
     "url": "https://github.com/martyroque/apps-digest.git"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "files": [
     "dist/",

--- a/src/AppsDigestInjectable.ts
+++ b/src/AppsDigestInjectable.ts
@@ -1,20 +1,25 @@
 import { AppsDigestContainer } from './AppsDigestContainer';
-import { AppsDigestStoreDefinition } from './types';
+import {
+  AppsDigestStoreDefinition,
+  AppsDigestStoreConstructable,
+} from './types';
 
 abstract class AppsDigestInjectable {
   private injectedStores: Map<string, AppsDigestStoreDefinition<unknown>> =
     new Map();
   private storeContainer = AppsDigestContainer.getInstance();
 
-  protected inject<S>(storeDefinition: AppsDigestStoreDefinition<S>): S {
+  protected inject<S>(store: AppsDigestStoreConstructable<S>): S {
+    const storeDefinition = this.storeContainer.getStoreDefinition(store);
+
     this.injectedStores.set(storeDefinition.storeId, storeDefinition);
 
-    return this.storeContainer.get(storeDefinition);
+    return this.storeContainer.get(store);
   }
 
   public destroy(): void {
     for (const [, injectedStore] of this.injectedStores) {
-      this.storeContainer.remove(injectedStore);
+      this.storeContainer.remove(injectedStore.storeClass);
     }
   }
 }

--- a/src/__tests__/AppsDigestContainer.test.ts
+++ b/src/__tests__/AppsDigestContainer.test.ts
@@ -1,13 +1,10 @@
 import { AppsDigestContainer } from '../AppsDigestContainer';
-import { generateStoreDefinition } from '../utils';
 
 const mockDestroy = jest.fn();
 
 class MockStore {
   destroy = mockDestroy;
 }
-
-const mockStoreDefinition = generateStoreDefinition(MockStore);
 
 const storeContainer = AppsDigestContainer.getInstance();
 
@@ -17,12 +14,31 @@ describe('AppsDigestContainer tests', () => {
   });
 
   afterEach(() => {
-    storeContainer.remove(mockStoreDefinition);
+    storeContainer.remove(MockStore);
   });
 
   describe('get store', () => {
+    it('should not have store definition initially', () => {
+      expect('getStoreDefinition' in MockStore.prototype).toBe(false);
+    });
+
+    it('should generate store definition', () => {
+      storeContainer.get(MockStore);
+
+      expect('getStoreDefinition' in MockStore.prototype).toBe(true);
+    });
+
+    it('should return the same store definition', () => {
+      const prevStoreDefinition = storeContainer.getStoreDefinition(MockStore);
+      storeContainer.get(MockStore);
+
+      expect(prevStoreDefinition).toBe(
+        storeContainer.getStoreDefinition(MockStore),
+      );
+    });
+
     it('should return the store instance', () => {
-      const store = storeContainer.get(mockStoreDefinition);
+      const store = storeContainer.get(MockStore);
 
       expect(store).toBeInstanceOf(MockStore);
     });
@@ -30,28 +46,28 @@ describe('AppsDigestContainer tests', () => {
 
   describe('remove store', () => {
     it('should return false when store record was not found', () => {
-      expect(storeContainer.remove(mockStoreDefinition)).toBe(false);
+      expect(storeContainer.remove(MockStore)).toBe(false);
     });
 
     it('should return true when store record was found', () => {
-      storeContainer.get(mockStoreDefinition);
+      storeContainer.get(MockStore);
 
-      expect(storeContainer.remove(mockStoreDefinition)).toBe(true);
+      expect(storeContainer.remove(MockStore)).toBe(true);
     });
 
     it('should call destroy the store instance when store has only 1 reference', () => {
-      storeContainer.get(mockStoreDefinition);
+      storeContainer.get(MockStore);
 
-      storeContainer.remove(mockStoreDefinition);
+      storeContainer.remove(MockStore);
 
       expect(mockDestroy).toHaveBeenCalledTimes(1);
     });
 
     it('should not destroy the store instance when store has more than 1 reference', () => {
-      storeContainer.get(mockStoreDefinition);
-      storeContainer.get(mockStoreDefinition);
+      storeContainer.get(MockStore);
+      storeContainer.get(MockStore);
 
-      storeContainer.remove(mockStoreDefinition);
+      storeContainer.remove(MockStore);
 
       expect(mockDestroy).not.toHaveBeenCalled();
     });

--- a/src/__tests__/AppsDigestInjectable.test.ts
+++ b/src/__tests__/AppsDigestInjectable.test.ts
@@ -1,6 +1,5 @@
 import { AppsDigestInjectable } from '../AppsDigestInjectable';
 import { AppsDigestContainer } from '../AppsDigestContainer';
-import { generateStoreDefinition } from '../utils';
 
 const storeContainer = AppsDigestContainer.getInstance();
 
@@ -10,27 +9,23 @@ class MockSubStore {
   destroy = mockDestroy;
 }
 
-const mockSubStoreDefinition = generateStoreDefinition(MockSubStore);
-
 class MockStore extends AppsDigestInjectable {
-  public subStore = this.inject(mockSubStoreDefinition);
+  public subStore = this.inject(MockSubStore);
 }
-
-const mockStoreDefinition = generateStoreDefinition(MockStore);
 
 describe('AppsDigestInjectable tests', () => {
   it('should inject a store', () => {
-    const mockStore = storeContainer.get(mockStoreDefinition);
+    const mockStore = storeContainer.get(MockStore);
 
     expect(mockStore.subStore).toBeInstanceOf(MockSubStore);
 
-    storeContainer.remove(mockStoreDefinition);
+    storeContainer.remove(MockStore);
   });
 
   it('should destroy injected store when main store is destroyed', () => {
-    storeContainer.get(mockStoreDefinition);
+    storeContainer.get(MockStore);
 
-    storeContainer.remove(mockStoreDefinition);
+    storeContainer.remove(MockStore);
 
     expect(mockDestroy).toHaveBeenCalled();
   });

--- a/src/__tests__/AppsDigestStore.test.ts
+++ b/src/__tests__/AppsDigestStore.test.ts
@@ -1,7 +1,6 @@
 import { AppsDigestStore } from '../AppsDigestStore';
 import { AppsDigestContainer } from '../AppsDigestContainer';
 import { AppsDigestValue } from '../AppsDigestValue';
-import { generateStoreDefinition } from '../utils';
 
 const storeContainer = AppsDigestContainer.getInstance();
 
@@ -11,12 +10,10 @@ class MockSubStore {
   stringValue = new AppsDigestValue<string | undefined>(undefined);
 }
 
-const mockSubStoreDefinition = generateStoreDefinition(MockSubStore);
-
 const mockSubscribeCallback = jest.fn();
 
 class MockStore extends AppsDigestStore {
-  public subStore = this.inject(mockSubStoreDefinition);
+  public subStore = this.inject(MockSubStore);
 
   public computed = this.computedValue(
     [this.subStore.boolValue, this.subStore.stringValue],
@@ -31,19 +28,17 @@ class MockStore extends AppsDigestStore {
   }
 }
 
-const mockStoreDefinition = generateStoreDefinition(MockStore);
-
 describe('AppsDigestStore tests', () => {
   let mockStore: MockStore;
   let mockSubStore: MockSubStore;
   beforeEach(() => {
     jest.clearAllMocks();
-    mockStore = storeContainer.get(mockStoreDefinition);
-    mockSubStore = storeContainer.get(mockSubStoreDefinition);
+    mockStore = storeContainer.get(MockStore);
+    mockSubStore = storeContainer.get(MockSubStore);
   });
 
   afterEach(() => {
-    storeContainer.remove(mockStoreDefinition);
+    storeContainer.remove(MockStore);
   });
 
   describe('subscribeToStoreValue', () => {
@@ -54,7 +49,7 @@ describe('AppsDigestStore tests', () => {
     });
 
     it('should unsubscribe from all values when main store is removed', () => {
-      storeContainer.remove(mockStoreDefinition);
+      storeContainer.remove(MockStore);
 
       mockSubStore.testValue.publish(2);
 
@@ -78,7 +73,7 @@ describe('AppsDigestStore tests', () => {
       mockSubStore.boolValue.publish(false);
       mockSubStore.stringValue.publish(undefined);
 
-      storeContainer.remove(mockStoreDefinition);
+      storeContainer.remove(MockStore);
 
       mockSubStore.boolValue.publish(true);
       mockSubStore.stringValue.publish('TEST');

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -1,7 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
 import { AppsDigestValue } from '../AppsDigestValue';
-import { generateStoreDefinition } from '../utils';
 import { useAppsDigestStore, useAppsDigestValue } from '../hooks';
 
 const mockDestroy = jest.fn();
@@ -11,21 +10,17 @@ class MockStore {
   destroy = mockDestroy;
 }
 
-const mockStoreDefinition = generateStoreDefinition(MockStore);
-
 describe('AppsDigest hooks tests', () => {
   describe('useAppsDigestStore', () => {
     it('should return the store instance', () => {
-      const { result } = renderHook(() =>
-        useAppsDigestStore(mockStoreDefinition),
-      );
+      const { result } = renderHook(() => useAppsDigestStore(MockStore));
 
       expect(result.current).toBeInstanceOf(MockStore);
     });
 
     it('should remove the store instance', () => {
       const { unmount, rerender } = renderHook(() =>
-        useAppsDigestStore(mockStoreDefinition),
+        useAppsDigestStore(MockStore),
       );
 
       // trigger some rerenders to ensure a single store reference
@@ -43,9 +38,7 @@ describe('AppsDigest hooks tests', () => {
     let store: MockStore;
 
     beforeEach(() => {
-      const { result } = renderHook(() =>
-        useAppsDigestStore(mockStoreDefinition),
-      );
+      const { result } = renderHook(() => useAppsDigestStore(MockStore));
       store = result.current;
     });
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,22 +1,20 @@
 import { useCallback, useMemo } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 
-import { AppsDigestStoreDefinition } from './types';
+import { AppsDigestStoreConstructable } from './types';
 import { AppsDigestContainer } from './AppsDigestContainer';
 import { AppsDigestReadOnlyValueInterface } from './AppsDigestValue';
 
-function useAppsDigestStore<S>(
-  storeDefinition: AppsDigestStoreDefinition<S>,
-): S {
+function useAppsDigestStore<S>(store: AppsDigestStoreConstructable<S>): S {
   const appsDigestContainer = AppsDigestContainer.getInstance();
 
   const [getStore, cleanup] = useMemo(() => {
-    const store = appsDigestContainer.get(storeDefinition);
+    const storeInstance = appsDigestContainer.get(store);
     return [
-      () => store,
+      () => storeInstance,
       () => {
         return () => {
-          appsDigestContainer.remove(storeDefinition);
+          appsDigestContainer.remove(store);
         };
       },
     ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,3 @@ export * from './AppsDigestInjectable';
 export * from './AppsDigestStore';
 export * from './types';
 export * from './hooks';
-export * from './utils';


### PR DESCRIPTION
Abstract the store definition generation to the store container by adding a `getStoreDefinition` method to the store prototype, making it simpler to just export the stores instead of manually generating the store definition before exporting or using the store.

Other changes:
- Update version as a breaking change.
- Update README to reflect changes.
- Remove `generateStoreDefinition` from library exports.